### PR TITLE
fix plugin order

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,11 +11,11 @@ export default {
     },
     plugins: [
         resolve(),
-        typescript(),
-        // with @rollup/plugin-typescript
-        // typescript({
-        //   include: [/\.tsx?$/, /\.vue\?.*?lang=ts/]
-        // }),
         vue(),
+        // typescript(),
+        // with @rollup/plugin-typescript
+        typescript({
+          include: [/\.tsx?$/, /\.vue\?.*?lang=ts/]
+        }),
     ]
 }


### PR DESCRIPTION
Plugin order is important in rollup config. Vue should go first as it provides virtual typescript files.